### PR TITLE
Defines.override でテスト時の dart-define 注入を追加

### DIFF
--- a/monolith_define/CHANGELOG.md
+++ b/monolith_define/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.3
+
+- Added `Defines.override` to inject dart-define values at test time (e.g. Integration Tests under VS Code)
+
 ## 1.0.2
 
 - Fixed Flutter test mode condition logic in defines generator template

--- a/monolith_define/README.ja.md
+++ b/monolith_define/README.ja.md
@@ -8,6 +8,7 @@ Dart `--dart-define`コマンドに渡すためのJSONファイルと、プロ�
 * **JSONファイル自動生成**: `--dart-define-from-file`で利用可能なJSONファイルの出力
 * **型安全なアクセス**: 生成される`Defines`クラスによる実行時の定数アクセス
 * **ビルドツール連携**: Flutter/Dartビルドプロセスとの自動連携
+* **テスト時オーバーライド**: `--dart-define`を自由に使えない場合に `Defines.override` で定数を注入
 
 ## Getting started
 
@@ -39,6 +40,7 @@ define:
 上記設定により以下のファイルが生成される:
 
 **JSONファイル例** (`secrets/dart-define/development.json`):
+
 ```json
 {
   "FLAVOR": "development",
@@ -47,6 +49,7 @@ define:
 ```
 
 **生成される Defines クラス例**:
+
 ```dart
 final class Defines {
   static String get FLAVOR { ... }
@@ -77,6 +80,22 @@ void main() {
 }
 ```
 
+**テスト時オーバーライド（`Defines.override`）**:
+
+Integration Test（例: VS Code 上）など、`--dart-define` を自由に使えない場合に利用する。既存キーは上書きされ、未登録キーは追加される。
+
+```dart
+import 'package:foundation_metadata/gen/defines.dart';
+
+void main() {
+  Defines.override({
+    'EXAMPLE_KEY_FOR_TESTING': 'true',
+  });
+
+  // ...
+}
+```
+
 ## Additional information
 
 このパッケージはFlutterアプリケーションのマルチフレーバー開発に最適化されている。
@@ -84,9 +103,10 @@ void main() {
 開発効率の向上とリリース時のヒューマンエラーを防止する。
 
 **テスト環境での特別な機能**:
-- `flutter test`実行時にワークスペースディレクトリを自動検索
-- テスト用フレーバーのJSONファイルから動的に定数をロード
-- ビルド時定数とテスト時定数を透過的に切り替え
+* `flutter test`実行時にワークスペースディレクトリを自動検索
+* テスト用フレーバーのJSONファイルから動的に定数をロード
+* ビルド時定数とテスト時定数を透過的に切り替え
+* Integration Test 等向けに `Defines.override` による直接注入をサポート
 
 **ディレクトリ管理**: パッケージはdefineタスク実行時に必要なディレクトリを自動作成し、手動操作なしで適切なファイル構造の設定を保証する。
 

--- a/monolith_define/README.md
+++ b/monolith_define/README.md
@@ -7,6 +7,7 @@ It streamlines flavor-specific environment constant management and build-time co
 * **Automatic JSON File Generation**: Output JSON files usable with `--dart-define-from-file`
 * **Type-safe Access**: Runtime constant access through generated `Defines` classes
 * **Build Tool Integration**: Automatic integration with Flutter/Dart build processes
+* **Test-time Override**: Inject dart-define values via `Defines.override` when `--dart-define` cannot be used freely
 
 ## Getting started
 
@@ -38,6 +39,7 @@ define:
 The above configuration generates the following files:
 
 **JSON File Example** (`secrets/dart-define/development.json`):
+
 ```json
 {
   "FLAVOR": "development",
@@ -46,6 +48,7 @@ The above configuration generates the following files:
 ```
 
 **Generated Defines Class Example**:
+
 ```dart
 final class Defines {
   static String get FLAVOR { ... }
@@ -76,16 +79,33 @@ void main() {
 }
 ```
 
+**Test-time Override (`Defines.override`)**:
+
+Use this when `--dart-define` cannot be used freely, such as Integration Tests (e.g. under VS Code). Existing keys are overwritten; unregistered keys are added.
+
+```dart
+import 'package:foundation_metadata/gen/defines.dart';
+
+void main() {
+  Defines.override({
+    'EXAMPLE_KEY_FOR_TESTING': 'true',
+  });
+
+  // ...
+}
+```
+
 ## Additional information
 
 This package is optimized for multi-flavor development of Flutter applications.
 It improves development efficiency and prevents human errors during release by providing type-safe management of environment-specific configuration values and automating build-time constant injection.
 
 **Special Features for Test Environment**:
-- Automatically searches workspace directory when running `flutter test`
-- Dynamically loads constants from test flavor JSON files
-- Transparently switches between build-time constants and test-time constants
+* Automatically searches workspace directory when running `flutter test`
+* Dynamically loads constants from test flavor JSON files
+* Transparently switches between build-time constants and test-time constants
+* Supports direct value injection via `Defines.override` for Integration Tests and similar cases
 
 **Directory Management**: The package automatically creates necessary directories when executing define tasks, ensuring proper file structure setup without manual operations.
 
-This enables consistent use of environment constants in unit tests and integration tests as well. 
+This enables consistent use of environment constants in unit tests and integration tests as well.

--- a/monolith_define/lib/src/generator/defines_generator_template.dart
+++ b/monolith_define/lib/src/generator/defines_generator_template.dart
@@ -17,6 +17,24 @@ final class Defines {
     }
 {{/keys}}
 
+  /// Overrides dart-define values at test time.
+  /// Use this to inject values directly when `--dart-define` cannot be used
+  /// freely, such as Integration Tests (e.g. under VS Code).
+  ///
+  /// [defines] is a map of keys to values. Existing keys are overwritten;
+  /// unregistered keys are added.
+  ///
+  /// Example:
+  /// ```dart
+  /// Defines.override({
+  ///   "EXAMPLE_KEY_FOR_TESTING": "true",
+  /// });
+  /// ```
+  @visibleForTesting
+  static void override(Map<String, String> defines) {
+    _defineList.addAll(defines);
+  }
+
   /// ワークスペースディレクトリを検索する.
   static Directory _getWorkspace() {
     var result = Directory.current;
@@ -51,6 +69,12 @@ final class Defines {
   }
 
   static String? _get(String key) {
+    /// 上書きされた値があればそれを返す
+    final value = _defineList[key];
+    if (value != null) {
+      return value;
+    }
+
     if (_isFlutterTesting) {
       _ensureInitialized();
       return _defineList[key];

--- a/monolith_define/pubspec.yaml
+++ b/monolith_define/pubspec.yaml
@@ -1,6 +1,6 @@
 name: monolith_define
 description: A package that automatically generates JSON files for passing to the Dart --dart-define command and a Defines class for type-safe programmatic access. It streamlines environment constant management for different flavors and build-time constant injection.
-version: 1.0.2
+version: 1.0.3
 resolution: workspace
 repository: https://github.com/eaglesakura/flutter_monolith
 


### PR DESCRIPTION
# Summary

`monolith_define` にテスト時向けの `Defines.override` を追加し、`--dart-define` を自由に使えない環境（例: VS Code 上の Integration Test）でも定数を注入できるようにした。バージョンを 1.0.3 に上げ、CHANGELOG / README を更新した（refs #15）。

## Features

* 生成される `Defines` クラスに `@visibleForTesting` 付きの `Defines.override(Map<String, String>)` を追加
* `_get` で上書き値を優先参照するよう変更（既存キーは上書き、未登録キーは追加）
* README（日英）にテスト時オーバーライドの利用例を追記
* CHANGELOG に 1.0.3 の変更を記載し、`pubspec.yaml` の version を 1.0.3 に更新

## Fixed

## Deleted
